### PR TITLE
refactor: BO 서비스 리팩토링 및 DI 적용

### DIFF
--- a/src/main/java/com/lecture/backoffice/api/controller/backOfficeLectureController.java
+++ b/src/main/java/com/lecture/backoffice/api/controller/backOfficeLectureController.java
@@ -14,13 +14,12 @@ import java.util.List;
 /**
  * 강연 관련 API 엔드포인트
  */
-@RestController("backofficeLectureController")
 @RequestMapping("/api/backoffice/lectures")
-public class LectureController {
+public class backOfficeLectureController {
 
     private final LectureService lectureService;
 
-    public LectureController(LectureService lectureService) {
+    public backOfficeLectureController(LectureService lectureService) {
         this.lectureService = lectureService;
     }
 

--- a/src/main/java/com/lecture/backoffice/api/dto/LectureResponse.java
+++ b/src/main/java/com/lecture/backoffice/api/dto/LectureResponse.java
@@ -28,4 +28,8 @@ public class LectureResponse {
         this.endTime = lecture.getEndTime();
         this.description = lecture.getDescription();
     }
+
+    public static LectureResponse toResponse(Lecture lecture) {
+        return new LectureResponse(lecture);
+    }
 }

--- a/src/main/java/com/lecture/backoffice/application/service/AttendeeQueryService.java
+++ b/src/main/java/com/lecture/backoffice/application/service/AttendeeQueryService.java
@@ -1,8 +1,7 @@
 package com.lecture.backoffice.application.service;
 
-import com.lecture.backoffice.domain.repository.ReservationRepository;
+import com.lecture.backoffice.domain.repository.backOfficeReservationRepository;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,16 +11,14 @@ import java.util.List;
  */
 @Service
 public class AttendeeQueryService {
+    private final backOfficeReservationRepository backOfficeReservationRepository;
 
-    @Qualifier("backofficeReservationRepository")
-    private final ReservationRepository reservationRepository;
-
-    public AttendeeQueryService(ReservationRepository reservationRepository) {
-        this.reservationRepository = reservationRepository;
+    public AttendeeQueryService(backOfficeReservationRepository backOfficeReservationRepository) {
+        this.backOfficeReservationRepository = backOfficeReservationRepository;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<String> getAttendeesByLectureId(Long lectureId) {
-        return reservationRepository.findEmployeeNumbersByLectureId(lectureId);
+        return backOfficeReservationRepository.findEmployeeNumbersByLectureId(lectureId);
     }
 }

--- a/src/main/java/com/lecture/backoffice/application/service/LectureService.java
+++ b/src/main/java/com/lecture/backoffice/application/service/LectureService.java
@@ -4,12 +4,11 @@ import com.lecture.backoffice.api.dto.LectureRequest;
 import com.lecture.backoffice.api.dto.LectureResponse;
 import com.lecture.backoffice.application.validator.LectureValidator;
 import com.lecture.backoffice.domain.repository.LectureAvailabilityRepository;
+import com.lecture.backoffice.domain.repository.backOfficeLectureRepository;
 import com.lecture.common.domain.model.Lecture;
-import com.lecture.backoffice.domain.repository.LectureRepository;
 import com.lecture.common.domain.model.LectureAvailability;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,56 +21,49 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class LectureService {
-
-    @Qualifier("backofficeLectureRepository")
-    private final LectureRepository lectureRepository;
+    private final backOfficeLectureRepository lectureRepository;
     private final LectureAvailabilityRepository lectureAvailabilityRepository;
-    private final LectureValidator lectureValidator;
 
-    public LectureService(LectureRepository lectureRepository, LectureAvailabilityRepository lectureAvailabilityRepository, LectureValidator lectureValidator) {
+    public LectureService(backOfficeLectureRepository lectureRepository, LectureAvailabilityRepository lectureAvailabilityRepository) {
         this.lectureRepository = lectureRepository;
         this.lectureAvailabilityRepository = lectureAvailabilityRepository;
-        this.lectureValidator = lectureValidator;
     }
 
     // 강연 등록
     @Transactional
     public LectureResponse createLecture(LectureRequest dto) {
         log.info("강연 등록 요청: {}", dto);
-        // 시간 범위 검증
-        lectureValidator.validateTimeRange(dto.getStartTime(), dto.getEndTime());
+        validateLectureTime(dto);
 
-        // 1. Lecture 객체 생성 (빌더 패턴 사용)
-        Lecture lecture = Lecture.builder()
-                .lecturer(dto.getLecturer())
-                .venue(dto.getVenue())
-                .capacity(dto.getCapacity())
-                .startTime(dto.getStartTime())
-                .endTime(dto.getEndTime())
-                .description(dto.getDescription())
-                .build();
+        Lecture lecture = Lecture.toLecture(dto);
+        Lecture savedLecture = saveLecture(lecture);
+        createAvailability(savedLecture);
 
-        // 2. 강연 정보 저장 (Lecture 테이블에 생성)
-        Lecture savedLecture = lectureRepository.save(lecture);
-        log.info("강연 등록 성공: id={}", savedLecture.getId());
+        return LectureResponse.toResponse(savedLecture);
+    }
 
-        // 3. LectureAvailability 생성
+    private void validateLectureTime(LectureRequest dto) {
+        LectureValidator.validateTimeRange(dto.getStartTime(), dto.getEndTime());
+    }
+
+    private Lecture saveLecture(Lecture lecture) {
+        Lecture saved = lectureRepository.save(lecture);
+        log.info("강연 등록 성공: id={}", saved.getId());
+        return saved;
+    }
+
+    private void createAvailability(Lecture savedLecture) {
         LectureAvailability availability = LectureAvailability.builder()
-                .lecture(savedLecture)  // 연관관계 설정: MapsId 사용 시, lecture의 id가 자동으로 availability의 id로 설정됨
-                .availableSeats(savedLecture.getCapacity()) // 초기 availableSeats는 강연 정원과 동일
+                .lecture(savedLecture)
+                .availableSeats(savedLecture.getCapacity())
                 .reservedCount(0)
                 .build();
-
-        // 4. lecture_availability 테이블에 저장
         lectureAvailabilityRepository.save(availability);
         log.info("예약 관리 정보 생성 성공: lecture_id={}", availability.getLectureId());
-
-        // 5. LectureResponseDto 생성 후 반환 (강연 정보 포함)
-        return new LectureResponse(savedLecture);
     }
 
     // 모든 강연 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public List<LectureResponse> getAllLectures() {
         List<LectureResponse> dtos = lectureRepository.findAll().stream()
                 .map(LectureResponse::new)

--- a/src/main/java/com/lecture/backoffice/application/validator/LectureValidator.java
+++ b/src/main/java/com/lecture/backoffice/application/validator/LectureValidator.java
@@ -19,7 +19,7 @@ public class LectureValidator {
      * @param startTime 강연 시작 시간
      * @param endTime   강연 종료 시간
      */
-    public void validateTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+    public static void validateTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
         if(startTime == null || endTime == null || !endTime.isAfter(startTime)) {
             log.error("강연 등록 실패: 잘못된 시간 입력, startTime={}, endTime={}", startTime, endTime);
             throw new IllegalArgumentException("잘못된 시간 입력: 종료 시간은 시작 시간보다 늦어야 합니다.");

--- a/src/main/java/com/lecture/backoffice/domain/repository/backOfficeLectureRepository.java
+++ b/src/main/java/com/lecture/backoffice/domain/repository/backOfficeLectureRepository.java
@@ -10,8 +10,8 @@ import java.util.List;
 /**
  * Lecture 엔티티의 CRUD 작업을 위한 Repository
  */
-@Repository("backofficeLectureRepository")
-public class LectureRepository {
+@Repository
+public class backOfficeLectureRepository {
 
     @PersistenceContext
     private EntityManager em;

--- a/src/main/java/com/lecture/backoffice/domain/repository/backOfficeReservationRepository.java
+++ b/src/main/java/com/lecture/backoffice/domain/repository/backOfficeReservationRepository.java
@@ -9,8 +9,8 @@ import java.util.List;
 /**
  * Reservation 엔티티의 CRUD 및 커스텀 쿼리 작업을 위한 Repository
  */
-@Repository("backofficeReservationRepository")
-public class ReservationRepository {
+@Repository
+public class backOfficeReservationRepository {
 
     @PersistenceContext
     private EntityManager em;

--- a/src/main/java/com/lecture/common/domain/model/Lecture.java
+++ b/src/main/java/com/lecture/common/domain/model/Lecture.java
@@ -1,5 +1,6 @@
 package com.lecture.common.domain.model;
 
+import com.lecture.backoffice.api.dto.LectureRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -36,4 +37,15 @@ public class Lecture extends BaseEntity {
     // 강연 내용 (최대 1000자)
     @Column(length = 1000)
     private String description;
+
+    public static Lecture toLecture(LectureRequest dto) {
+        return Lecture.builder()
+                .lecturer(dto.getLecturer())
+                .venue(dto.getVenue())
+                .capacity(dto.getCapacity())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .description(dto.getDescription())
+                .build();
+    }
 }


### PR DESCRIPTION
### 강연 등록 서비스 리팩토링 및 DI 적용

#### 주요 변경 사항
- `LectureService` 내 `createLecture()` 메서드의 복잡한 로직을 책임 단위로 메서드 분리하여 **단일 책임 원칙(SRP)**을 반영
- `LectureValidator`, `LectureAvailabilityRepository`, `backOfficeLectureRepository`는 생성자 주입(생성자 기반 DI) 방식으로 명확하게 주입
- `Lecture` 및 `LectureResponse`에 정적 팩토리 메서드(`toLecture`, `toResponse`) 도입 → DTO ↔ 도메인 변환 책임을 각 도메인으로 이동
- `@Transactional(readOnly = true)`를 전체 강연 조회 로직에 명시 → 트랜잭션 오버헤드 최소화
